### PR TITLE
fixes to make build error go away. Made gen.bat copy the relevant fil…

### DIFF
--- a/gen.bat
+++ b/gen.bat
@@ -3,5 +3,10 @@ call xcopy "bobo\libs\FMODAPI\api\core\lib\x64\fmod.dll" "bin\Debug-windows-x86_
 call xcopy "bobo\libs\FMODAPI\api\studio\lib\x64\fmodstudio.dll" "bin\Debug-windows-x86_64\bobo\" /y
 call xcopy "bobo\libs\FMODAPI\api\core\lib\x64\fmod.dll" "bin\Release-windows-x86_64\bobo\" /y
 call xcopy "bobo\libs\FMODAPI\api\studio\lib\x64\fmodstudio.dll" "bin\Release-windows-x86_64\bobo\" /y
+call xcopy "bobo\libs\imgui\backends\imgui_impl_glfw.cpp" "bobo\libs\imgui\" /y
+call xcopy "bobo\libs\imgui\backends\imgui_impl_glfw.h" "bobo\libs\imgui\" /y
+call xcopy "bobo\libs\imgui\backends\imgui_impl_opengl3.h" "bobo\libs\imgui\" /y
+call xcopy "bobo\libs\imgui\backends\imgui_impl_opengl3.cpp" "bobo\libs\imgui\" /y
+call xcopy "bobo\libs\imgui\backends\imgui_impl_opengl3_loader.h" "bobo\libs\imgui\" /y
 call premake\premake5.exe vs2022
 PAUSE

--- a/premake5.lua
+++ b/premake5.lua
@@ -65,6 +65,9 @@ project "bobo"
 		"bobo/libs/FMODAPI/api/studio/lib/x64/fmodstudio_vc.lib"
     }
 
+	filter "files:bobo/libs/imgui/*"
+		flags {"NoPCH"}
+
     filter "system:windows"
         cppdialect "C++17"
         staticruntime "off"


### PR DESCRIPTION
…es to imgui folder and made premake5 build the solution ensuring that the imgui.cpp files do not require us including the precompiled header